### PR TITLE
Add blank properties

### DIFF
--- a/jobs/idp/templates/config/shibboleth/relying-party.xml
+++ b/jobs/idp/templates/config/shibboleth/relying-party.xml
@@ -30,4 +30,17 @@
         </property>
     </bean>
 
+    <!--
+     - README: These are purposefully left blank.
+     -->
+    <util:list id="shibboleth.RelyingPartyOverrides">
+    </util:list>
+    <bean id="shibboleth.UnverifiedRelyingParty" parent="RelyingParty">
+        <property name="profileConfigurations">
+            <list>
+<!--                 <bean parent="SAML2.SSO" p:encryptAssertions="false" />
+ -->            </list>
+        </property>
+    </bean>
+
 </beans>


### PR DESCRIPTION
This adds the RelyingPartyOverrides and UnverifiedRelyingParty blocks to the relying-party configuration. They're purposefully left blank.