### PR TITLE
Metadata requires no BEGIN/END headers for keys and certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,24 +83,24 @@ openssl req -new \
 
 Add the following properties to the `my-secrets.yml` file:
 
+> Do **NOT** include the `-----BEGIN RSA PRIVATE KEY-----` or `-----END RSA PRIVATE KEY-----`
+> for the keys, nor `-----BEGIN CERTIFICATE-----` or `-----END CERTIFICATE-----` for
+> the certs.
+
 ```yaml
 ---
 properties:
   idp:
     signing:
       key: | # Specifies your private SAML signing key
-        -----BEGIN RSA PRIVATE KEY-----
-        -----END RSA PRIVATE KEY-----
+        YOUR KEY HERE
       cert: | # Specifies your public SAML certificate.
-        -----BEGIN CERTIFICATE-----
-        -----END CERTIFICATE-----
+        YOUR CERT HERE
     encryption:
       key: | # Specifies your private SAML encryption key
-        -----BEGIN RSA PRIVATE KEY-----
-        -----END RSA PRIVATE KEY-----
+        YOUR KEY HERE
       cert: | # Specifies your public SAML encryption certificate.
-        -----BEGIN CERTIFICATE-----
-        -----END CERTIFICATE-----
+        YOUR CERT HERE
 ```
 
 You now suffix this file path to the `make_manifest` command:

--- a/jobs/idp/templates/credentials/idp-encryption.crt.erb
+++ b/jobs/idp/templates/credentials/idp-encryption.crt.erb
@@ -1,1 +1,3 @@
+-----BEGIN CERTIFICATE-----
 <%= p('idp.encryption.cert') %>
+-----END CERTIFICATE-----

--- a/jobs/idp/templates/credentials/idp-encryption.key.erb
+++ b/jobs/idp/templates/credentials/idp-encryption.key.erb
@@ -1,1 +1,3 @@
+-----BEGIN RSA PRIVATE KEY-----
 <%= p('idp.encryption.key') %>
+-----END RSA PRIVATE KEY-----

--- a/jobs/idp/templates/credentials/idp-signing.crt.erb
+++ b/jobs/idp/templates/credentials/idp-signing.crt.erb
@@ -1,1 +1,3 @@
+-----BEGIN CERTIFICATE-----
 <%= p('idp.signing.cert') %>
+-----END CERTIFICATE-----

--- a/jobs/idp/templates/credentials/idp-signing.key.erb
+++ b/jobs/idp/templates/credentials/idp-signing.key.erb
@@ -1,1 +1,3 @@
+-----BEGIN RSA PRIVATE KEY-----
 <%= p('idp.signing.key') %>
+-----END RSA PRIVATE KEY-----


### PR DESCRIPTION
@rogeruiz 