### PR TITLE
Add configurable totp-authn-config and bean

### DIFF
--- a/jobs/idp/spec
+++ b/jobs/idp/spec
@@ -262,7 +262,10 @@ properties:
     default: "true"
   idp.totp.database.userSeedTable:
     description: "Table used to store users for authenication"
-    default: "seed_table"
+    default: "totp_seed"
+  idp.totp.database.userColumn:
+    description: "Column for the user in the table"
+    default: "username"
   idp.totp.database.seedColumn:
     description: "Column for the seed in the table"
-    default: "seed_value"
+    default: "seed"

--- a/jobs/idp/spec
+++ b/jobs/idp/spec
@@ -29,7 +29,7 @@ templates:
   config/shibboleth/authn/password-authn-config.xml: config/shibboleth/authn/password-authn-config.xml
   config/shibboleth/authn/general-authn.xml: config/shibboleth/authn/general-authn.xml
   config/shibboleth/authn/totp-authn-config.xml.erb: config/shibboleth/authn/totp-authn-config.xml
-  config/shibboleth/authn/totp-authn-beans.xml: config/shibboleth/authn/totp-authn-beans.xml
+  config/shibboleth/authn/totp-authn-beans.xml.erb: config/shibboleth/authn/totp-authn-beans.xml
   credentials/idp-signing.crt.erb: credentials/idp-signing.crt
   credentials/idp-signing.key.erb: credentials/idp-signing.key
   credentials/idp-encryption.crt.erb: credentials/idp-encryption.crt

--- a/jobs/idp/spec
+++ b/jobs/idp/spec
@@ -260,6 +260,16 @@ properties:
   idp.jaas.database.useBcrypt:
     description: "Does the password column use BCrypt for password storage"
     default: "true"
+  idp.totp.database.dbDriver:
+    description: "JDBC driver class to use for Totp authentication"
+    default: "org.postgresql.Driver"
+  idp.totp.database.dbURL
+    description: "JDBC URL of the database to use for totp authentication"
+    example: "jdc:postgresql://host/database"
+  idp.totp.database.dbUser:
+    description: "Username for the totp authentication database"
+  idp.totp.database.dbPassword:
+    description: "Password for the totp authentication database"
   idp.totp.database.userSeedTable:
     description: "Table used to store users for authenication"
     default: "totp_seed"

--- a/jobs/idp/spec
+++ b/jobs/idp/spec
@@ -28,6 +28,7 @@ templates:
   config/shibboleth/authn/jaas-authn-config.xml: config/shibboleth/authn/jaas-authn-config.xml
   config/shibboleth/authn/password-authn-config.xml: config/shibboleth/authn/password-authn-config.xml
   config/shibboleth/authn/general-authn.xml: config/shibboleth/authn/general-authn.xml
+  config/shibboleth/authn/totp-authn-config.xml.erb: config/shibboleth/authn/totp-authn-config.xml
   config/shibboleth/authn/totp-authn-beans.xml: config/shibboleth/authn/totp-authn-beans.xml
   credentials/idp-signing.crt.erb: credentials/idp-signing.crt
   credentials/idp-signing.key.erb: credentials/idp-signing.key
@@ -259,3 +260,9 @@ properties:
   idp.jaas.database.useBcrypt:
     description: "Does the password column use BCrypt for password storage"
     default: "true"
+  idp.totp.database.userSeedTable:
+    description: "Table used to store users for authenication"
+    default: "seed_table"
+  idp.totp.database.seedColumn:
+    description: "Column for the seed in the table"
+    default: "seed_value"

--- a/jobs/idp/templates/config/shibboleth/authn/totp-authn-beans.xml.erb
+++ b/jobs/idp/templates/config/shibboleth/authn/totp-authn-beans.xml.erb
@@ -22,13 +22,21 @@
   <bean id="TotpTokenValidator" class="net.kvak.shibboleth.totpauth.authn.impl.TotpTokenValidator" scope="prototype"
     p:httpServletRequest-ref="shibboleth.HttpServletRequest" p:seedFetcher-ref="shibboleth.totp.seedfetcher" p:gAuth-ref="shibboleth.totp.gAuth" />
 
-    <bean id="RegisterNewToken" class="net.kvak.shibboleth.totpauth.authn.impl.RegisterNewToken" scope="prototype"
+    <bean id="RegisterNewToken" class="net.kvak.shibboleth.totpauth.authn.impl.RegisterNewSeedSql" scope="prototype"
         p:httpServletRequest-ref="shibboleth.HttpServletRequest"
         p:gAuth-ref="shibboleth.totp.gAuth"
-        p:ldapTemplate-ref="ldapTemplate"
-        p:tokenCodeField-ref="shibboleth.authn.tokenCodeField">
-        <constructor-arg ref="shibboleth.authn.seedAttribute" />
-        <constructor-arg ref="shibboleth.authn.userAttribute" />
+        p:seedDataSource-ref="seedDataSource"
+        p:tokenCodeField-ref="shibboleth.authn.tokenCodeField"
+        p:seedDBTableName-ref="shibboleth.authn.seedDBTableName"
+        p:usernameColumnName-ref="shibboleth.authn.usernameColumnName"
+        p:seedColumnName-ref="shibboleth.authn.seedColumnName">
+    </bean>
+
+    <bean id="seedDataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
+      <property name="driverClassName" value="<%= p('idp.totp.database.dbDriver') %>"/>
+      <property name="url" value="<%= p('idp.totp.database.dbURL') %>"/>
+      <property name="username" value="<%= p('idp.totp.database.dbUser') %>"/>
+      <property name="password" value="<%= p('idp.totp.database.dbPassword') %>"/>
     </bean>
 
     <bean id="GenerateNewToken" class="net.kvak.shibboleth.totpauth.authn.impl.GenerateNewToken" scope="prototype"

--- a/jobs/idp/templates/config/shibboleth/authn/totp-authn-config.xml.erb
+++ b/jobs/idp/templates/config/shibboleth/authn/totp-authn-config.xml.erb
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:util="http://www.springframework.org/schema/util" xmlns:p="http://www.springframework.org/schema/p" xmlns:c="http://www.springframework.org/schema/c"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
+
+	default-init-method="initialize" default-destroy-method="destroy">
+
+	<!-- Names of form fields to pull tokenNumber -->
+	<bean id="shibboleth.authn.tokenCodeField" class="java.lang.String" c:_0="j_tokenNumber" />
+
+	<!-- TOTP Seed DB related fields -->
+  <bean id="shibboleth.authn.seedDBTableName" class="java.lang.String" c:_0="<%= p('idp.totp.database.userSeedTable') %>"/>
+  <bean id="shibboleth.authn.usernameColumnName" class="java.lang.String" c:_0="<%= p('idp.totp.database.userColumn') %>"/>
+  <bean id="shibboleth.authn.seedColumnName" class="java.lang.String" c:_0="<%= p('idp.totp.database.seedColumn') %>"/>
+	<!-- LDAP related fields -->
+	<bean id="shibboleth.authn.seedAttribute" class="java.lang.String" c:_0="carLicense" />
+	<bean id="shibboleth.authn.userAttribute" class="java.lang.String" c:_0="uid" />
+
+	<!-- GoogleAuthenticator class to be injected to the TOTP validator. Default settings (offset 3 codes and so on) -->
+	<bean id="shibboleth.totp.gAuth" class="com.warrenstrange.googleauth.GoogleAuthenticator" />
+
+</beans>


### PR DESCRIPTION
This patch series adds the totp-authn-config file from the Totp plugin and pulls @jbarnicle's work from the plugin submodule.