### PR TITLE
Templatize authn-messages to include lockout period in message

### DIFF
--- a/jobs/idp/spec
+++ b/jobs/idp/spec
@@ -37,6 +37,7 @@ templates:
   credentials/idp-encryption.key.erb: credentials/idp-encryption.key
   edit-webapp/css/main.css.erb: edit-webapp/css/main.css
   messages/error-messages.properties.erb: messages/error-messages.properties
+  messages/authn-messages.properties.erb: messages/authn-messages.properties
   metadata/idp-metadata.xml.erb: metadata/idp-metadata.xml
 
 properties:

--- a/jobs/idp/templates/messages/authn-messages.properties.erb
+++ b/jobs/idp/templates/messages/authn-messages.properties.erb
@@ -55,7 +55,7 @@ bad-password.message = The password you entered was incorrect.
 
 expired-password.message = Your password has expired.
 
-account-locked.message = Your account is locked. Please try logging in again in <%= p('idp.authentication.failurePeriodSeconds') %> seconds.
+account-locked.message = Your account is locked. Please try logging in again in <%= p('idp.authentication.failurePeriodSeconds') / 60 %> minutes.
 
 spnego-unavailable.message = Your web browser doesn't support authentication with your desktop login credentials.
 spnego-unavailable.return = Cancel the attempt.

--- a/jobs/idp/templates/messages/authn-messages.properties.erb
+++ b/jobs/idp/templates/messages/authn-messages.properties.erb
@@ -1,0 +1,73 @@
+# In addition to the Apache 2.0 license, this content is also licensed
+# under the Creative Commons Attribution-ShareAlike 3.0 Unported license
+# (see http://creativecommons.org/licenses/by-sa/3.0/).
+
+# Login / Logout messages
+
+idp.login.loginTo = Login to
+
+idp.login.username = Username
+idp.login.password = Password
+
+idp.login.donotcache = Don't Remember Login
+
+idp.login.login = Login
+idp.login.pleasewait = Logging in, please wait...
+
+idp.login.forgotPassword = Forgot your password?
+idp.login.needHelp = Need Help?
+
+# Expiring password example messages
+
+idp.login.expiringSoon = Your password will be expiring soon!
+idp.login.changePassword = To create a new password now, go to
+idp.login.proceedBegin = Your login will proceed in 20 seconds or you may click
+idp.login.proceedHere = here
+idp.login.proceedEnd = to continue
+
+# Useful links
+
+idp.url.password.reset = #
+idp.url.helpdesk = #
+
+# User Preferences example messages
+
+idp.userprefs.title = Web Login Service
+idp.userprefs.title.suffice = Login Preferences
+idp.userprefs.info = This page allows you to configure your device to tell the Web Login Service that it \
+                        can use more advanced login approaches that are more convenient, but not always usable.
+idp.userprefs.options = The following options are available:
+idp.userprefs.spnego = Automatically try desktop login when available.
+idp.userprefs.no-js = This feature requires Javascript.
+
+# Classified Login Error messages
+
+UnknownUsername = bad-username
+InvalidPassword = bad-password
+ExpiredPassword = expired-password
+AccountLocked = account-locked
+SPNEGONotAvailable = spnego-unavailable
+NTLMUnsupported = ntlm
+
+bad-username.message = The username you entered cannot be identified.
+
+bad-password.message = The password you entered was incorrect.
+
+expired-password.message = Your password has expired.
+
+account-locked.message = Your account is locked. Please try logging in again in <%= p('idp.authentication.failurePeriodSeconds') %> seconds.
+
+spnego-unavailable.message = Your web browser doesn't support authentication with your desktop login credentials.
+spnego-unavailable.return = Cancel the attempt.
+
+ntlm.message = Your web browser attempted to negotiate a weaker form of desktop authentication.
+
+# Logout-related messages
+
+idp.logout.ask = Would you like to attempt to log out of all services accessed during your session? \
+                    Please select <strong>Yes</strong> or <strong>No</strong> to ensure the logout \
+                    operation completes, or wait a few seconds for Yes.
+idp.logout.contactServices = If you proceed, the system will attempt to contact the following services:
+idp.logout.complete = The logout operation is complete, and no other services appear to have been accessed during this session.
+idp.logout.local = You elected not to log out of all the applications accessed during your session.
+idp.logout.attempt = Attempting to log out of the following services:

--- a/jobs/idp/templates/messages/authn-messages.properties.erb
+++ b/jobs/idp/templates/messages/authn-messages.properties.erb
@@ -55,7 +55,7 @@ bad-password.message = The password you entered was incorrect.
 
 expired-password.message = Your password has expired.
 
-account-locked.message = Your account is locked. Please try logging in again in <%= p('idp.authentication.failurePeriodSeconds') / 60 %> minutes.
+account-locked.message = Your account is locked. Please try logging in again in <%= p('idp.authentication.failurePeriodSeconds') / 60.to_f %> minutes.
 
 spnego-unavailable.message = Your web browser doesn't support authentication with your desktop login credentials.
 spnego-unavailable.return = Cancel the attempt.


### PR DESCRIPTION
@LinuxBozo @rogeruiz I'm not sure how to convert the `idp.authentication.failurePeriodSeconds` to minutes - I think we would maybe want that for the messaging?