### PR TITLE
Update "username" to "email address" in login UI

### DIFF
--- a/jobs/idp/templates/messages/authn-messages.properties.erb
+++ b/jobs/idp/templates/messages/authn-messages.properties.erb
@@ -6,7 +6,7 @@
 
 idp.login.loginTo = Login to
 
-idp.login.username = Username
+idp.login.username = Email address
 idp.login.password = Password
 
 idp.login.donotcache = Don't Remember Login
@@ -15,7 +15,7 @@ idp.login.login = Login
 idp.login.pleasewait = Logging in, please wait...
 
 idp.login.forgotPassword = Forgot your password?
-idp.login.needHelp = Need Help?
+idp.login.needHelp = Need help?
 
 # Expiring password example messages
 


### PR DESCRIPTION
For the page at https://idp.fr.cloud.gov/profile/SAML2/POST/SSO?execution=e2s1, I believe that what we really want from people as a username is actually their email address, so I updated the string that seems to provide that info.