### PR TITLE
Turn off overly verbose stack traces

### DIFF
--- a/jobs/idp/templates/config/tomcat/server.xml.erb
+++ b/jobs/idp/templates/config/tomcat/server.xml.erb
@@ -71,6 +71,9 @@
             unpackWARs="true"
             autoDeploy="false"
             failCtxIfServletStartFails="true">
+        <Valve className="org.apache.catalina.valves.ErrorReportValve"
+               showReport="false"
+               showServerInfo="false" />
         <Valve className="org.apache.catalina.valves.RemoteIpValve"
                remoteIpHeader="x-forwarded-for"
                protocolHeader="<%= p('idp.ssl.protocol_header') %>"


### PR DESCRIPTION
In order to reduce potential log messages which could contain sensitive information.[1][2]

1. https://tomcat.apache.org/tomcat-7.0-doc/security-howto.html
2. https://www.owasp.org/index.php/Securing_tomcat
