### PR TITLE
Username case sensitivity workaround

### DIFF
--- a/src/tagish/src/main/java/com/tagish/auth/FileLogin.java
+++ b/src/tagish/src/main/java/com/tagish/auth/FileLogin.java
@@ -65,7 +65,7 @@ public class FileLogin extends SimpleLogin
 		}
 
 		if (users == null || !users.containsKey(username))
-		   throw new AccountExpiredException("Unknown user");
+		   throw new AccountExpiredException("Unknown email address - if you have an account, try entering your email in all lowercase letters");
 		User u = (User) users.get(username);
 		char pwd[];
 		try {


### PR DESCRIPTION
Before:

<img width="617" alt="screen shot 2017-12-18 at 1 19 45 pm" src="https://user-images.githubusercontent.com/391313/34128637-35235214-e3f6-11e7-8ba5-a87f1fcbb48c.png">

After (using inspect element):

<img width="590" alt="screen shot 2017-12-18 at 1 20 11 pm" src="https://user-images.githubusercontent.com/391313/34128642-3895d868-e3f6-11e7-8dd5-ed33544d7f55.png">
