### PR TITLE
idp: update x509 rendering

### DIFF
--- a/jobs/idp/templates/credentials/idp-encryption.crt.erb
+++ b/jobs/idp/templates/credentials/idp-encryption.crt.erb
@@ -1,3 +1,1 @@
------BEGIN CERTIFICATE-----
 <%= p('idp.encryption.cert') %>
------END CERTIFICATE-----

--- a/jobs/idp/templates/credentials/idp-encryption.key.erb
+++ b/jobs/idp/templates/credentials/idp-encryption.key.erb
@@ -1,3 +1,1 @@
------BEGIN RSA PRIVATE KEY-----
 <%= p('idp.encryption.key') %>
------END RSA PRIVATE KEY-----

--- a/jobs/idp/templates/credentials/idp-signing.crt.erb
+++ b/jobs/idp/templates/credentials/idp-signing.crt.erb
@@ -1,3 +1,1 @@
------BEGIN CERTIFICATE-----
 <%= p('idp.signing.cert') %>
------END CERTIFICATE-----

--- a/jobs/idp/templates/credentials/idp-signing.key.erb
+++ b/jobs/idp/templates/credentials/idp-signing.key.erb
@@ -1,3 +1,1 @@
------BEGIN RSA PRIVATE KEY-----
 <%= p('idp.signing.key') %>
------END RSA PRIVATE KEY-----

--- a/jobs/idp/templates/metadata/idp-metadata.xml.erb
+++ b/jobs/idp/templates/metadata/idp-metadata.xml.erb
@@ -17,7 +17,7 @@
             <ds:KeyInfo>
                     <ds:X509Data>
                         <ds:X509Certificate>
-<%= p('idp.signing.cert') %>
+<%= p('idp.signing.cert').lines[1..-2].join %>
                         </ds:X509Certificate>
                     </ds:X509Data>
             </ds:KeyInfo>
@@ -26,7 +26,7 @@
             <ds:KeyInfo>
                     <ds:X509Data>
                         <ds:X509Certificate>
-<%= p('idp.encryption.cert') %>
+<%= p('idp.encryption.cert').lines[1..-2].join %>
                         </ds:X509Certificate>
                     </ds:X509Data>
             </ds:KeyInfo>
@@ -61,7 +61,7 @@
             <ds:KeyInfo>
                     <ds:X509Data>
                         <ds:X509Certificate>
-<%= p('idp.signing.cert') %>
+<%= p('idp.signing.cert').lines[1..-2].join %>
                         </ds:X509Certificate>
                     </ds:X509Data>
             </ds:KeyInfo>
@@ -70,7 +70,7 @@
             <ds:KeyInfo>
                     <ds:X509Data>
                         <ds:X509Certificate>
-<%= p('idp.encryption.cert') %>
+<%= p('idp.encryption.cert').lines[1..-2].join %>
                         </ds:X509Certificate>
                     </ds:X509Data>
             </ds:KeyInfo>


### PR DESCRIPTION
## Changes Proposed

there's a disparity between certificates in use, some need to be PEM
format, and some need to be in DER format. this defaults to PEM format
wherever possible and then strips the headers where it needs to be DER
format.

## Security Considerations

None.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>
