### PR TITLE
fix template syntax

### DIFF
--- a/jobs/idp/templates/views/logout.vm.erb
+++ b/jobs/idp/templates/views/logout.vm.erb
@@ -36,7 +36,7 @@
           <div class="column one">
 
             #if ( $logoutContext and !$logoutContext.getSessionMap().isEmpty() )
-                <p>#springMessageText("idp.logout.ask", "Would you like to logout?</p>
+                <p>#springMessageText("idp.logout.ask", "Would you like to logout?")</p>
                 <br>
 
                 <form id="propagate_form" method="POST" action="$flowExecutionUrl">


### PR DESCRIPTION
## Changes Proposed

- fix the syntax of the Velocity template for logging out. This will allow users to see a friendly logout message instead of a java stacktrace

## Security Considerations

None