### PR TITLE
use the correct execute statement for inserts

### DIFF
--- a/src/tagish/src/main/java/com/tagish/auth/DBLogin.java
+++ b/src/tagish/src/main/java/com/tagish/auth/DBLogin.java
@@ -225,7 +225,6 @@ public class DBLogin extends SimpleLogin
     username = username.toLowerCase();
     log.info("[AUDIT] Username: " + username + " EventType: " + eventType.getCode() + " Origin: " + origin);
     if (!auditTable.isEmpty()) {
-      ResultSet rsu = null, rsr = null;
       PreparedStatement psu = null;
 
       try {
@@ -242,7 +241,7 @@ public class DBLogin extends SimpleLogin
         psu.setInt(2, eventType.getCode());
         psu.setTimestamp(3, now);
         psu.setString(4, origin);
-        rsu = psu.executeQuery();
+        psu.executeUpdate(); 
       } catch (Exception e) {
         // Log the exception
         log.error("TROUBLE", e);


### PR DESCRIPTION
## Changes Proposed

Inserts do not return result sets. Therefore, we need to use executeUpdate instead of executeQuery. executeQuery was throwing an exception.

## Security Considerations

None
