### PR TITLE
Add bean for preserving older Shibboleth behavior

### DIFF
--- a/jobs/idp/templates/config/shibboleth/authn/password-authn-config.xml
+++ b/jobs/idp/templates/config/shibboleth/authn/password-authn-config.xml
@@ -31,6 +31,9 @@
     <!-- Set to TRUE if you want the password kept in the resulting Subject as a private credential. -->
     <util:constant id="shibboleth.authn.Password.RetainAsPrivateCredential" static-field="java.lang.Boolean.FALSE"/>
 
+    <!-- Preserve the object holding the password for the entire request lifecycle - required for the Shibboleth TOTP plugin -->
+    <util:constant id="shibboleth.authn.Password.RemoveAfterValidation" static-field="java.lang.Boolean.FALSE" />
+
     <!-- Apply any regular expression replacement pairs before validation. -->
     <util:list id="shibboleth.authn.Password.Transforms">
         <!--


### PR DESCRIPTION
This changeset adds a new bean config for preserving the older behavior from Shibboleth 3.2.x that the Shibboleth TOTP plugin expects.

## Changes Proposed
- Adds a config line for the [`shibboleth.authn.Password.RemoveAfterValidation`](https://shibboleth.atlassian.net/wiki/spaces/IDP30/pages/2494726322/PasswordAuthnConfiguration#PasswordAuthnConfiguration-Beans) bean

## Security Considerations
- Attempting to make Shibboleth work properly again for the cloud.gov IDP